### PR TITLE
Support for election halt/resume + election state changes restrictions

### DIFF
--- a/docs/deployment/assets/config.auth.yml
+++ b/docs/deployment/assets/config.auth.yml
@@ -415,6 +415,11 @@ config:
     # should set this to false; else, set it to true (default).
     private_path_verify_ssl_client_certificate: true
 
+    # Defines if there's a tight control of the allowed state transitions
+    # within an election. For example, an stopped election wouldn't be allowed
+    # to be re-started if this is enable. Defaults to true.
+    enforce_state_controls: true
+
     # In an election, a voter can change his vote as a way to mitigate coercion.
     # Here you can set the maximum number of vote changes. Set to 1 to disable
     # vote changing.

--- a/docs/deployment/assets/config.master.yml
+++ b/docs/deployment/assets/config.master.yml
@@ -415,6 +415,11 @@ config:
     # should set this to false; else, set it to true (default).
     private_path_verify_ssl_client_certificate: true
 
+    # Defines if there's a tight control of the allowed state transitions
+    # within an election. For example, an stopped election wouldn't be allowed
+    # to be re-started if this is enable. Defaults to true.
+    enforce_state_controls: true
+
     # In an election, a voter can change his vote as a way to mitigate coercion.
     # Here you can set the maximum number of vote changes. Set to 1 to disable
     # vote changing.


### PR DESCRIPTION
There are two different things that are added related to this PR:
1. support for start/stop vs suspend/resume the voting period. The idea is that after you stop an election voting period it cannot be re-started, but when you suspend it temporarely, it can be resumed later on. 
2. Enforcement of election state controls. This is optional, but now it **will be enabled by default* (BREAKING CHANGE). When enabled (it can be disabled in `config.yml` throught the `config.agora_elections.enforce_state_controls` option), this enforcement means that we'll apply higher restrictions on what state transitions are allowed. For example, starting an election when it is already stopped won't be allowed - unless this enforcement setting is disabled. The same kind of logic applies to all other election state transitions.